### PR TITLE
Use element scale when animating button

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -333,9 +333,11 @@ AFRAME.registerComponent("button", {
         // Using aframe animations for button and its children scale (pic, text..)
         // Using tween.js for color change due to problems with aframe color animations
 
+        const elScale = this.el.object3D.scale.clone();
+
         const pressAnimation = {
             property: 'scale',
-            to: { x: 0.9, y: 0.9, z: 0.9 },
+            to: { x: elScale.x * 0.9, y: elScale.y * 0.9, z: elScale.z * 0.9 },
             dur: 100,
             easing: 'easeInOutQuad'
         };
@@ -361,7 +363,7 @@ AFRAME.registerComponent("button", {
         }
     
         setTimeout(() => {
-            const releaseAnimation = { ...pressAnimation, to: { x: 1, y: 1, z: 1 } };
+            const releaseAnimation = { ...pressAnimation, to: { x: elScale.x, y: elScale.y, z: elScale.z } };
             this.el.setAttribute('animation__click', releaseAnimation);
     
             new TWEEN.Tween(buttonMesh.material.color)


### PR DESCRIPTION
This PR fixes the scale problem that appears when you press the button. The old button when released increases the scale of the object to (1, 1, 1), which is incorrect because the object may have an initial scale other than (1, 1, 1).

Here is an example of the problem where there is a single button that has a scale of (0.5, 0.5, 0.5).

![button-animation-issue](https://github.com/user-attachments/assets/dd8c44d5-9296-44c8-9d7f-615095f51574)

After the fix, the button when released uses the initial scale of the object.

![fix](https://github.com/user-attachments/assets/fbf675c4-c2b4-4865-b1d5-64759bdea0eb)


