### PR TITLE
Feat/textfield keyboard detection

### DIFF
--- a/primitives/ar-textbox.js
+++ b/primitives/ar-textbox.js
@@ -1,24 +1,22 @@
-import '../components/textbox.js'
-import '../components/virtualKeyboard.js'
+import "../components/textbox.js";
+import "../components/virtualKeyboard.js";
 
-AFRAME.registerPrimitive('a-ar-textbox', {
-    defaultComponents: {
-      textbox: {},
-      virtualKeyboard: {},
+AFRAME.registerPrimitive("a-ar-textbox", {
+  defaultComponents: {
+    textbox: {},
+    virtualKeyboard: {},
+  },
 
-    },
-  
-    mappings: {
-      primary: 'textbox.primary',
-      visible: 'geometry.visible',
-      position: 'geometry.position',
-      size: 'textbox.size',
-      bordercolor: 'textbox.bordercolor',
-      textcolor: 'textbox.textcolor',
-      label: 'textbox.label',
-      isactivated: 'textbox.isactivated',
-      variant: 'textbox.variant',
-    }
-  });
-
-  
+  mappings: {
+    primary: "textbox.primary",
+    visible: "geometry.visible",
+    position: "geometry.position",
+    size: "textbox.size",
+    bordercolor: "textbox.bordercolor",
+    textcolor: "textbox.textcolor",
+    label: "textbox.label",
+    isactivated: "textbox.isactivated",
+    variant: "textbox.variant",
+    usesystemkeyboard: "textbox.usesystemkeyboard",
+  },
+});

--- a/tereza-demo/index.html
+++ b/tereza-demo/index.html
@@ -9,10 +9,10 @@
   <body>
     <div id="app" style="position: absolute; height: 100%; width: 100%"></div>
     <!-- Import console into VR scene if needed -->
-    <!-- <script src="https://unpkg.com/vconsole@latest/dist/vconsole.min.js"></script>
+    <script src="https://unpkg.com/vconsole@latest/dist/vconsole.min.js"></script>
     <script>
       new VConsole();
-    </script> -->
+    </script>
     <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/tereza-demo/main.js
+++ b/tereza-demo/main.js
@@ -8,6 +8,7 @@ import "../primitives/ar-button.js";
 import "../primitives/ar-textbox.js";
 import "../components/autoXr.js";
 import "../components/controllers.js";
+import "../components/vrInteractive.js";
 
 document.querySelector("#app").innerHTML = `
 <a-scene auto-xr>
@@ -15,5 +16,5 @@ document.querySelector("#app").innerHTML = `
   <a-entity id="rig" controllers>
     </a-entity>
 
-    <a-ar-textbox label="Name" placeholder="Enter your name" position="0 1.5 -2" useSystemKeyboard></a-ar-textbox>
+    <a-ar-textbox label="Name" placeholder="Enter your name" position="0 1.5 -2" usesystemkeyboard="true" vr-interactive></a-ar-textbox>
     </a-scene>`;


### PR DESCRIPTION
This newly added prop **useSystemKeyboard** should support using _system_ keyboard instead of _virtual_ keyboard. 

There are mostly formatting differences, changed functionality is mainly in _switchActivated()_ fnc

Docs [here](https://github.com/SpatialHub-MENDELU/spatial-design-system-docs/pull/56)