### PR TITLE
gameview: third-person-follow type 

### DIFF
--- a/components/game/gameview.js
+++ b/components/game/gameview.js
@@ -82,8 +82,7 @@ AFRAME.registerComponent("gameview", {
         if (!isValidGameKey(this.data.keyTurnRight)) this.wrongInput = true
 
         if (!this.wrongInput) {
-            const needsTarget = ['thirdPersonFollow', 'thirdPersonFixed', 'quarterTurn'].includes(this.data.type);
-            if (needsTarget && !this.data.target?.object3D) {
+            if (this.isTargetNeeded && !this.data.target?.object3D) {
                 console.error("Target is missing or invalid.");
                 this.wrongInput = true;
             }


### PR DESCRIPTION
# gameview component 
**quarterTurn**
- The camera is positioned behind and above the player. When pressing the E or Q key, the camera snaps 90° around the player while continuously looking at them.
- Customize the camera movement by `keyTurnLeft`, `keyTurnRight` and `rotationSpeed` 

**thirdPersonFixed**
- The camera stays behind the player but does not rotate when the player turns. If the player moves back, the camera moves backward instead of rotating.

# What's new 
**thirdPersonFollow**
- The camera is positioned behind and slightly above the player. It rotates along with the player, always keeping them in view. 
- You can set the camera position using `height`, `distance`, and `tilt`. When you set it up correctly, you can use this camera type as a first-person view camera. 