### PR TITLE
fix(menu): prevent crash when items is empty or invalid JSON

### DIFF
--- a/components/menu.js
+++ b/components/menu.js
@@ -95,7 +95,29 @@ AFRAME.registerComponent("menu", {
     },
 
     prepareItems() {
-        const parsedItems = JSON.parse(this.data.items.replaceAll("'", "\""))
+        let parsedItems = []
+        const rawItems = this.data.items
+
+        if (typeof rawItems === "string") {
+            const normalizedItems = rawItems.replaceAll("'", "\"").trim()
+            if (normalizedItems !== "") {
+                try {
+                    const items = JSON.parse(normalizedItems)
+                    if (Array.isArray(items)) {
+                        parsedItems = items
+                    } else {
+                        console.warn('[menu] "items" must be a JSON array string.', items)
+                    }
+                } catch (error) {
+                    console.warn('[menu] Failed to parse "items" JSON.', rawItems, error)
+                }
+            }
+        } else if (Array.isArray(rawItems)) {
+            parsedItems = [...rawItems]
+        } else if (rawItems !== null && rawItems !== undefined) {
+            console.warn('[menu] "items" must be a JSON array string.', rawItems)
+        }
+
         if(parsedItems.length > 6) {
             alert("Maximum of 6 items allowed")
             parsedItems.splice(6)


### PR DESCRIPTION
## Summary
This PR fixes a crash in `menu.prepareItems()` when `items` is missing, empty, malformed, or not a JSON array.

## Problem
`menu` schema defaults `items` to an empty string (`""`), but `prepareItems()` called `JSON.parse(...)` unconditionally. That caused runtime errors like `Unexpected end of JSON input` and broke component init.

## Changes
- Added guarded parsing in `components/menu.js`:
  - handles empty strings safely
  - wraps JSON parsing in `try/catch`
  - validates parsed value is an array
  - logs warnings for invalid input instead of throwing
- Kept existing normalization behavior (max 6 items, min 2 fallback substitution)

## Why this is safe
- No API change for valid inputs.
- Invalid inputs now degrade gracefully instead of crashing.

## Verification
- Built library successfully with `npm run build`.
- Reproduced crash scenario and confirmed no init crash after fix.

Closes #120